### PR TITLE
Precise call identifier snippets with evidences

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/posthog/posthog-go v1.5.12
-	github.com/safedep/code v0.0.0-20250610122234-1c9ee24b7317
-	github.com/safedep/dry v0.0.0-20250613153337-39475c3f0d64
+	github.com/safedep/code v0.0.0-20250619080228-57f5b7b5e58c
+	github.com/safedep/dry v0.0.0-20250618113059-9f8b677e299c
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -362,10 +362,10 @@ github.com/ryancurrah/gomodguard v1.3.5 h1:cShyguSwUEeC0jS7ylOiG/idnd1TpJ1LfHGpV
 github.com/ryancurrah/gomodguard v1.3.5/go.mod h1:MXlEPQRxgfPQa62O8wzK3Ozbkv9Rkqr+wKjSxTdsNJE=
 github.com/ryanrolds/sqlclosecheck v0.5.1 h1:dibWW826u0P8jNLsLN+En7+RqWWTYrjCB9fJfSfdyCU=
 github.com/ryanrolds/sqlclosecheck v0.5.1/go.mod h1:2g3dUjoS6AL4huFdv6wn55WpLIDjY7ZgUR4J8HOO/XQ=
-github.com/safedep/code v0.0.0-20250610122234-1c9ee24b7317 h1:7+g5Yx5qUm/AC8MFS9JZq220KPkxwFKTllQ4smVDMsg=
-github.com/safedep/code v0.0.0-20250610122234-1c9ee24b7317/go.mod h1:dwBhRQG722MBp9fGvqdYESnOZpl5dzTKVImRKcwQMNw=
-github.com/safedep/dry v0.0.0-20250613153337-39475c3f0d64 h1:bUjtTt0UlCEHqjl3V4dOiA+sj2Lf4B/lvSuIK5DPhSM=
-github.com/safedep/dry v0.0.0-20250613153337-39475c3f0d64/go.mod h1:nU5w9Xb5Ja2wq5PU/K8r8r1Dc25ApJXKKqvwju99G2w=
+github.com/safedep/code v0.0.0-20250619080228-57f5b7b5e58c h1:ao6OCJyNomRFgpRtVbTEa5KetcPlinf/3rJEkL0Pgz8=
+github.com/safedep/code v0.0.0-20250619080228-57f5b7b5e58c/go.mod h1:5gnHWxq6kbun+r3qf52UHD5f9bd36sWhkDLXvPRd4ZA=
+github.com/safedep/dry v0.0.0-20250618113059-9f8b677e299c h1:xr6P3xzQqxPx93qbH/LPjyK46oEEA6N0nYyiQSjikkI=
+github.com/safedep/dry v0.0.0-20250618113059-9f8b677e299c/go.mod h1:8GbUOzdf46FT4j5h9lw9DdA3wM9NgIVEZjTfkzNe+Cw=
 github.com/sanposhiho/wastedassign/v2 v2.1.0 h1:crurBF7fJKIORrV85u9UUpePDYGWnwvv3+A96WvwXT0=
 github.com/sanposhiho/wastedassign/v2 v2.1.0/go.mod h1:+oSmSC+9bQ+VUAxA66nBb0Z7N8CK7mscKTDYC6aIek4=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=

--- a/pkg/bom/cyclondex.go
+++ b/pkg/bom/cyclondex.go
@@ -117,17 +117,17 @@ func (c *CycloneDXGenerator) RecordCodeAnalysisFindings(findings *codeanalysis.C
 			for _, condition := range signatureMatchResult.MatchedConditions {
 				for _, evidence := range condition.Evidences {
 					metadata := evidence.Metadata(signatureMatchResult.TreeData)
-					evidenceOccurence := cdx.EvidenceOccurrence{
+					evidenceOccurrence := cdx.EvidenceOccurrence{
 						Location:          signatureMatchResult.FilePath,
 						AdditionalContext: metadata.CalleeNamespace,
 					}
 
 					if metadata.CallerIdentifierMetadata != nil {
-						evidenceOccurence.Line = utils.PtrTo(int(metadata.CallerIdentifierMetadata.StartLine + 1))
-						evidenceOccurence.Offset = utils.PtrTo(int(metadata.CallerIdentifierMetadata.StartColumn + 1))
+						evidenceOccurrence.Line = utils.PtrTo(int(metadata.CallerIdentifierMetadata.StartLine + 1))
+						evidenceOccurrence.Offset = utils.PtrTo(int(metadata.CallerIdentifierMetadata.StartColumn + 1))
 					}
 
-					*occurrences = append(*occurrences, evidenceOccurence)
+					*occurrences = append(*occurrences, evidenceOccurrence)
 				}
 			}
 		}

--- a/pkg/bom/cyclondex.go
+++ b/pkg/bom/cyclondex.go
@@ -116,15 +116,18 @@ func (c *CycloneDXGenerator) RecordCodeAnalysisFindings(findings *codeanalysis.C
 		for _, signatureMatchResult := range signatureMatchResults {
 			for _, condition := range signatureMatchResult.MatchedConditions {
 				for _, evidence := range condition.Evidences {
-					metadata, exists := evidence.Metadata()
-					if exists {
-						*occurrences = append(*occurrences, cdx.EvidenceOccurrence{
-							Location:          signatureMatchResult.FilePath,
-							Line:              utils.PtrTo(int(metadata.StartLine + 1)),
-							Offset:            utils.PtrTo(int(metadata.StartColumn + 1)),
-							AdditionalContext: evidence.Namespace,
-						})
+					metadata := evidence.Metadata(signatureMatchResult.TreeData)
+					evidenceOccurence := cdx.EvidenceOccurrence{
+						Location:          signatureMatchResult.FilePath,
+						AdditionalContext: metadata.CalleeNamespace,
 					}
+
+					if metadata.CallerIdentifierMetadata != nil {
+						evidenceOccurence.Line = utils.PtrTo(int(metadata.CallerIdentifierMetadata.StartLine + 1))
+						evidenceOccurence.Offset = utils.PtrTo(int(metadata.CallerIdentifierMetadata.StartColumn + 1))
+					}
+
+					*occurrences = append(*occurrences, evidenceOccurence)
 				}
 			}
 		}

--- a/pkg/codeanalysis/workflow.go
+++ b/pkg/codeanalysis/workflow.go
@@ -13,6 +13,11 @@ type CodeAnalysisWorkflowConfig struct {
 	Callbacks         *CodeAnalysisCallbackRegistry
 }
 
+type EnrichedSignatureMatchResult struct {
+	callgraph.SignatureMatchResult
+	TreeData *[]byte
+}
+
 type CodeAnalysisFindings struct {
-	SignatureWiseMatchResults map[string][]callgraph.SignatureMatchResult
+	SignatureWiseMatchResults map[string][]EnrichedSignatureMatchResult
 }

--- a/pkg/reporter/html.go
+++ b/pkg/reporter/html.go
@@ -1,5 +1,3 @@
-// Keep your package and imports as is
-
 package reporter
 
 import (
@@ -40,195 +38,9 @@ func (hv *HTMLVisualiser) Finish(htmlPath string) error {
 		"ruby":       "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/ruby/ruby-original.svg",
 	}
 
-	tmpl := `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Signature Visualizer</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
-    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
-</head>
-
-<body>
-<!-- Top Nav Bar -->
-<nav class="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-  <!-- Logo on the left -->
-  <a href="https://safedep.io/" class="flex items-center">
-  <img src="https://avatars.githubusercontent.com/u/115209633?s=200&v=4" alt="Logo" class="h-10 w-10 rounded-md mr-3">
-  <span class="font-semibold text-lg text-gray-800">SafeDep</span>
-</a>
-
-  <!-- Star xbom on GitHub on the right -->
-  <a href="https://github.com/safedep/xbom" target="_blank" rel="noopener noreferrer"
-     class="flex items-center bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium px-4 py-2 rounded transition">
-    <!-- GitHub Logo SVG -->
-    <svg class="h-5 w-5 mr-2" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M12 0C5.37 0 0 5.373 0 12c0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577
-      0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.729.083-.729
-      1.205.085 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.305.76-1.605-2.665-.305-5.466-1.334-5.466-5.93
-      0-1.31.468-2.38 1.236-3.22-.124-.303-.535-1.523.117-3.176 0 0 1.008-.322 3.3 1.23a11.52 11.52 0 013.003-.404c1.02.005
-      2.047.138 3.003.404 2.29-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.873.12 3.176.77.84 1.235 1.91 1.235 3.22
-      0 4.61-2.803 5.624-5.475 5.92.43.37.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565
-      21.796 24 17.298 24 12c0-6.627-5.373-12-12-12z"/>
-    </svg>
-    Star us on GitHub
-  </a>
-</nav>
-
-<div class="bg-gray-100 min-h-screen flex items-start justify-center p-6">
-    <div class="bg-white p-8 rounded-2xl shadow-xl w-full max-w-6xl space-y-6 mt-[0] mb-[1%] sticky top-0">
-        <h1 class="text-3xl font-bold mb-6 text-gray-800">Matched Signatures</h1>
-
-        <!-- Filters -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-                <label class="block text-gray-700 mb-2" for="signatureSelect">Signature ID</label>
-                <select id="signatureSelect" class="w-full border border-gray-300 rounded-lg p-2" multiple>
-                    {{ range $index, $row := .Rows }}
-                    <option value="{{ $row.Signature_ID }}">{{ $row.Signature_ID }}</option>
-                    {{ end }}
-                </select>
-            </div>
-
-            <div>
-                <label class="block text-gray-700 mb-2" for="tagsSelect">Tags</label>
-                <select id="tagsSelect" class="w-full border border-gray-300 rounded-lg p-2" multiple>
-                    {{ range $tag := .UniqueTags }}
-                        <option value="{{ $tag }}">{{ $tag }}</option>
-                    {{ end }}
-                </select>
-            </div>
-        </div>
-
-        <!-- Table -->
-        <div class="overflow-x-auto rounded-lg shadow bg-white">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-100">
-                    <tr>
-                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Signature ID</th>
-                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Description</th>
-                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Tags</th>
-                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Details</th>
-                    </tr>
-                </thead>
-                <tbody id="signatureTable" class="bg-white divide-y divide-gray-200">
-                    {{ range $index, $row := .Rows }}
-                    <tr data-signature="{{ $row.Signature_ID }}" data-tags="{{ $row.Tags }}">
-                        <td class="px-4 py-2 text-sm text-gray-900">{{ $row.Signature_ID }}</td>
-                        <td class="px-4 py-2 text-sm text-gray-900">{{ $row.Description }}</td>
-                        <td class="px-4 py-2 text-sm text-gray-700">{{ $row.Tags }}</td>
-                        <td class="px-4 py-2 text-sm">
-                            <button class="flex items-center gap-1 text-blue-600 focus:outline-none font-medium px-2 py-1 rounded transition-colors duration-150 cursor-pointer border border-blue-200 bg-blue-50 hover:bg-blue-100"
-                                onclick="toggleDetails('details-{{ $index }}', this)">
-                                <span class="icon mr-1 transition-transform duration-200">&#9654;</span>
-                                <span>Show Details</span>
-                            </button>
-                        </td>
-                    </tr>
-                    <tr id="details-{{ $index }}" class="details hidden">
-                        <td colspan="4" class="bg-gray-50 px-4 py-2">
-                            <div class="space-y-4">
-                                {{ range $row.FileOccurrences }}
-                                <div class="border rounded-lg p-4 bg-white shadow-md hover:shadow-lg transition-shadow duration-300">
-                                    <div class="flex flex-wrap items-center gap-4 mb-2">
-                                        <div class="text-xs text-gray-600"><strong>File:</strong> <span class="font-mono">{{ .File }}</span></div>
-                                        <div class="flex items-center text-xs text-gray-600">
-                                            <strong>Language:</strong> 
-                                            {{ if (index $.LanguageIconMap (lower .Language)) }}
-                                                <img src="{{ index $.LanguageIconMap (lower .Language) }}" alt="{{ .Language }}" class="w-4 h-4 mx-1">
-                                            {{ end }}
-                                            <span>{{ .Language }}</span>
-                                        </div>
-                                    </div>
-                                    <ul class="flex flex-wrap gap-2 mt-2">
-                                        {{ range .Occurrences }}
-                                        <li class="text-xs text-gray-700 bg-gray-200 rounded-full px-3 py-1 border">{{ . }}</li>
-                                        {{ end }}
-                                    </ul>
-                                </div>
-                                {{ end }}
-                            </div>
-                        </td>
-                    </tr>
-                    {{ end }}
-                </tbody>
-            </table>
-        </div>
-    </div>
-    </div>
-
-    <script>
-        const signatureSelect = document.getElementById('signatureSelect');
-        const tagsSelect = document.getElementById('tagsSelect');
-        const signatureChoices = new Choices(signatureSelect, { removeItemButton: true });
-        const tagChoices = new Choices(tagsSelect, { removeItemButton: true });
-
-        signatureSelect.addEventListener('change', filterTable);
-        tagsSelect.addEventListener('change', filterTable);
-
-        function filterTable() {
-            const selectedSignatures = signatureChoices.getValue(true);
-            const selectedTags = tagChoices.getValue(true);
-            const rows = document.querySelectorAll('#signatureTable tr');
-
-            for (let i = 0; i < rows.length; i += 2) {
-                const row = rows[i];
-                const rowSignature = row.getAttribute('data-signature');
-                const rowTags = row.getAttribute('data-tags').split(',').map(tag => tag.trim());
-                const detailRow = rows[i + 1];
-
-                const signatureMatch = (selectedSignatures.length === 0 || selectedSignatures.includes(rowSignature));
-                const tagsMatch = (selectedTags.length === 0 || selectedTags.some(tag => rowTags.includes(tag)));
-
-                if (signatureMatch && tagsMatch) {
-                    row.style.display = '';
-                    detailRow.style.display = '';
-                } else {
-                    row.style.display = 'none';
-                    detailRow.style.display = 'none';
-                }
-            }
-        }
-
-        function toggleDetails(id, btn) {
-            var x = document.getElementById(id);
-            var icon = btn.querySelector('.icon');
-            if (x.classList.contains("hidden")) {
-                x.classList.remove("hidden");
-                icon.style.transform = "rotate(90deg)";
-                btn.querySelector('span:last-child').textContent = "Hide Details";
-            } else {
-                x.classList.add("hidden");
-                icon.style.transform = "rotate(0deg)";
-                btn.querySelector('span:last-child').textContent = "Show Details";
-            }
-        }
-    </script>
-    <!-- Example Tailwind CSS Footer -->
-    <footer class="bg-gray-50 text-gray-600 py-6 border-t border-gray-200">
-      <div class="container mx-auto flex flex-col md:flex-row items-center justify-between px-4">
-        <span class="text-sm">&copy; 2025 SafeDep. All rights reserved.</span>
-        <div class="flex space-x-4 mt-4 md:mt-0">
-          <a href="https://safedep.io/privacy" class="hover:text-gray-400 transition">Privacy Policy</a>
-          <a href="https://safedep.io/terms" class="hover:text-gray-400 transition">Terms of Service</a>
-        </div>
-      </div>
-    </footer>
-    </body>
-</html>`
-
 	t := template.Must(template.New("report").Funcs(template.FuncMap{
-		"splitTags": func(tags string) []string {
-			tagList := strings.Split(tags, ",")
-			for i := range tagList {
-				tagList[i] = strings.TrimSpace(tagList[i])
-			}
-			return tagList
-		},
 		"lower": strings.ToLower,
-	}).Parse(tmpl))
+	}).Parse(htmlTemplate))
 
 	f, err := os.Create(htmlPath)
 	if err != nil {
@@ -245,6 +57,7 @@ func (hv *HTMLVisualiser) Finish(htmlPath string) error {
 			"Description":     row["Description"],
 			"Tags":            row["Tags"],
 			"FileOccurrences": row["FileOccurrences"],
+			"CallerSnippets":  row["CallerSnippets"],
 		})
 
 		tags := strings.Split(row["Tags"].(string), ",")
@@ -262,7 +75,6 @@ func (hv *HTMLVisualiser) Finish(htmlPath string) error {
 	return t.Execute(f, map[string]interface{}{
 		"Headers":         headers,
 		"Rows":            rows,
-		"UniqueTags":      uniqueTags,
 		"LanguageIconMap": languageIconMap,
 	})
 }
@@ -273,34 +85,58 @@ func VisualiseCodeAnalysisFindings(codeAnalysisFindings *codeanalysis.CodeAnalys
 	sigRows := map[string]map[string]interface{}{}
 
 	for _, signatureResults := range codeAnalysisFindings.SignatureWiseMatchResults {
-		// fmt.Println(sigid, ":", len(signatureResults), "matches")
-
-		for _, match := range signatureResults {
-			sig := match.MatchedSignature
+		for _, signatureMatchResult := range signatureResults {
+			sig := signatureMatchResult.MatchedSignature
 			sigId := sig.Id
 			desc := sig.Description
 			tags := strings.Join(sig.Tags, ", ")
 
 			fileMap := make(map[string]map[string]interface{})
-			for _, condition := range match.MatchedConditions {
+
+			for _, condition := range signatureMatchResult.MatchedConditions {
 				for _, evidence := range condition.Evidences {
-					evidenceDetailString := "Unknown"
-					evidenceContent, exists := evidence.Metadata()
-					if exists {
-						evidenceDetailString = fmt.Sprintf("L%d:%d to L%d:%d",
-							evidenceContent.StartLine, evidenceContent.StartColumn,
-							evidenceContent.EndLine, evidenceContent.EndColumn)
-					}
-					conditionLocationString := fmt.Sprintf("%s - %s", condition.Condition.Type, strings.ReplaceAll(condition.Condition.Value, "\n", " "))
-					key := match.FilePath + "|" + string(match.MatchedLanguageCode)
+					evidenceMetadata := evidence.Metadata(signatureMatchResult.TreeData)
+
+					key := signatureMatchResult.FilePath + "|" + string(signatureMatchResult.MatchedLanguageCode)
 					if _, ok := fileMap[key]; !ok {
 						fileMap[key] = map[string]interface{}{
-							"File":        match.FilePath,
-							"Language":    string(match.MatchedLanguageCode),
-							"Occurrences": []string{},
+							"File":     signatureMatchResult.FilePath,
+							"Language": string(signatureMatchResult.MatchedLanguageCode),
+							"Matches":  []map[string]interface{}{},
 						}
 					}
-					fileMap[key]["Occurrences"] = append(fileMap[key]["Occurrences"].([]string), fmt.Sprintf("%s - %s", conditionLocationString, evidenceDetailString))
+
+					conditionValueString := fmt.Sprintf("%s - %s", condition.Condition.Type, strings.ReplaceAll(condition.Condition.Value, "\n", " "))
+
+					// Create a match object with occurrence and snippet
+					match := map[string]interface{}{
+						"Occurrence": fmt.Sprintf("%s", conditionValueString),
+						"Snippet":    nil,
+					}
+
+					// Add snippet if available
+					if evidenceMetadata.CallerIdentifierMetadata != nil && strings.TrimSpace(evidenceMetadata.CallerIdentifierContent) != "" {
+						lines := strings.Split(evidenceMetadata.CallerIdentifierContent, "\n")
+						snippetLines := make([]map[string]interface{}, len(lines))
+						startLine := int(evidenceMetadata.CallerIdentifierMetadata.StartLine)
+
+						for i, line := range lines {
+							snippetLines[i] = map[string]interface{}{
+								"LineNum": startLine + i + 1,
+								"Content": line,
+							}
+						}
+
+						match["Snippet"] = map[string]interface{}{
+							"Lines": snippetLines,
+						}
+					}
+
+					// Add the match to the file's matches array
+					fileMap[key]["Matches"] = append(
+						fileMap[key]["Matches"].([]map[string]interface{}),
+						match,
+					)
 				}
 			}
 

--- a/pkg/reporter/html.go
+++ b/pkg/reporter/html.go
@@ -127,7 +127,7 @@ func VisualiseCodeAnalysisFindings(codeAnalysisFindings *codeanalysis.CodeAnalys
 
 					// Create a match object with occurrence and snippet
 					match := map[string]interface{}{
-						"Occurrence": fmt.Sprintf("%s", conditionValueString),
+						"Occurrence": conditionValueString,
 						"Snippet":    nil,
 					}
 

--- a/pkg/reporter/html_template.go
+++ b/pkg/reporter/html_template.go
@@ -1,0 +1,149 @@
+package reporter
+
+var htmlTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Signature Visualizer</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+</head>
+<body>
+
+<nav class="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+    <a href="https://safedep.io/" class="flex items-center">
+        <img src="https://avatars.githubusercontent.com/u/115209633?s=200&v=4" alt="Logo" class="h-10 w-10 rounded-md mr-3">
+        <span class="font-semibold text-lg text-gray-800">SafeDep</span>
+    </a>
+    <a href="https://github.com/safedep/xbom" target="_blank" rel="noopener noreferrer"
+       class="flex items-center bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium px-4 py-2 rounded transition">
+        <svg class="h-5 w-5 mr-2" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 0C5.37 0 0 5.373 0 12c0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577
+                0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.729.083-.729
+                1.205.085 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.305.76-1.605-2.665-.305-5.466-1.334-5.466-5.93
+                0-1.31.468-2.38 1.236-3.22-.124-.303-.535-1.523.117-3.176 0 0 1.008-.322 3.3 1.23a11.52 11.52 0 013.003-.404c1.02.005
+                2.047.138 3.003.404 2.29-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.873.12 3.176.77.84 1.235 1.91 1.235 3.22
+                0 4.61-2.803 5.624-5.475 5.92.43.37.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565
+                21.796 24 17.298 24 12c0-6.627-5.373-12-12-12z"/>
+        </svg>
+        Star us on GitHub
+    </a>
+</nav>
+
+<div class="bg-gray-100 min-h-screen flex items-start justify-center p-6">
+    <div class="bg-white p-8 rounded-2xl shadow-xl w-full max-w-6xl space-y-6 mt-[0] mb-[1%] sticky top-0">
+        <h1 class="text-3xl font-bold mb-6 text-gray-800">Matched Signatures</h1>
+
+        <!-- Table -->
+        <div class="overflow-x-auto rounded-lg shadow bg-white">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-100">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Signature ID</th>
+                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Description</th>
+                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Tags</th>
+                        <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Details</th>
+                    </tr>
+                </thead>
+                <tbody id="signatureTable" class="bg-white divide-y divide-gray-200">
+                    {{ range $index, $row := .Rows }}
+                    <tr>
+                        <td class="px-4 py-2 text-sm text-gray-900">{{ $row.Signature_ID }}</td>
+                        <td class="px-4 py-2 text-sm text-gray-900">{{ $row.Description }}</td>
+                        <td class="px-4 py-2 text-sm text-gray-700">{{ $row.Tags }}</td>
+                        <td class="px-4 py-2 text-sm">
+                            <button class="flex items-center gap-1 text-blue-600 focus:outline-none font-medium px-2 py-1 rounded transition-colors duration-150 cursor-pointer border border-blue-200 bg-blue-50 hover:bg-blue-100"
+                                onclick="toggleDetails('details-{{ $index }}', this)">
+                                <span class="icon mr-1 transition-transform duration-200">&#9654;</span>
+                                <span>Show Details</span>
+                            </button>
+                        </td>
+                    </tr>
+                    <tr id="details-{{ $index }}" class="details hidden">
+                        <td colspan="4" class="bg-gray-50 px-4 py-2">
+                            <div class="space-y-4">
+                                {{ range $row.FileOccurrences }}
+                                <div class="border rounded-lg p-4 bg-white shadow-md hover:shadow-lg transition-shadow duration-300">
+                                    <div class="flex flex-wrap items-center gap-4 mb-2">
+                                        <div class="text-xs text-gray-600"><strong>File:</strong> <span class="font-mono">{{ .File }}</span></div>
+                                        <div class="flex items-center text-xs text-gray-600">
+                                            <strong>Language:</strong> 
+                                            {{ if (index $.LanguageIconMap (lower .Language)) }}
+                                                <img src="{{ index $.LanguageIconMap (lower .Language) }}" alt="{{ .Language }}" class="w-4 h-4 mx-1">
+                                            {{ end }}
+                                            <span>{{ .Language }}</span>
+                                        </div>
+                                    </div>
+                                    <div class="space-y-4 mt-2">
+                                        {{ range $index, $item := .Matches }}
+                                        <div class="border-t pt-4 first:border-t-0 first:pt-0">
+                                            <div class="text-xs text-gray-700 bg-gray-200 rounded-full px-3 py-1 border inline-block">{{ $item.Occurrence }}</div>
+                                            {{ if $item.Snippet }}
+                                            <div class="mt-2">
+                                                <div class="relative">
+                                                    <button onclick="copyToClipboard(this)" class="absolute right-2 top-2 text-xs bg-gray-700 text-white px-2 py-1 rounded hover:bg-gray-600">
+                                                        Copy
+                                                    </button>
+                                                    <pre class="bg-gray-900 text-[#1affeb] text-sm p-2 rounded overflow-x-auto font-mono"><code>{{ range $item.Snippet.Lines }}<span class="text-gray-500 mr-2">{{ .LineNum }}</span>{{ .Content }}
+{{ end }}</code></pre>
+                                                </div>
+                                            </div>
+                                            {{ end }}
+                                        </div>
+                                        {{ end }}
+                                    </div>
+                                </div>
+                                {{ end }}
+                            </div>
+                        </td>
+                    </tr>
+                    {{ end }}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script>
+function copyToClipboard(button) {
+    const pre = button.nextElementSibling;
+    const text = pre.textContent;
+    navigator.clipboard.writeText(text).then(() => {
+        const originalText = button.textContent;
+        button.textContent = 'Copied!';
+        button.disabled = true;
+        setTimeout(() => {
+            button.textContent = originalText;
+            button.disabled = false;
+        }, 2000);
+    });
+}
+
+function toggleDetails(id, btn) {
+        var x = document.getElementById(id);
+        var icon = btn.querySelector('.icon');
+        if (x.classList.contains("hidden")) {
+            x.classList.remove("hidden");
+            icon.style.transform = "rotate(90deg)";
+            btn.querySelector('span:last-child').textContent = "Hide Details";
+        } else {
+            x.classList.add("hidden");
+            icon.style.transform = "rotate(0deg)";
+            btn.querySelector('span:last-child').textContent = "Show Details";
+        }
+    }
+</script>
+
+<footer class="bg-gray-50 text-gray-600 py-6 border-t border-gray-200">
+    <div class="container mx-auto flex flex-col md:flex-row items-center justify-between px-4">
+        <span class="text-sm">&copy; 2025 SafeDep. All rights reserved.</span>
+        <div class="flex space-x-4 mt-4 md:mt-0">
+            <a href="https://safedep.io/privacy" class="hover:text-gray-400 transition">Privacy Policy</a>
+            <a href="https://safedep.io/terms" class="hover:text-gray-400 transition">Terms of Service</a>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>`

--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -37,23 +37,27 @@ func SummariseCodeAnalysisFindings(codeAnalysisFindings *codeanalysis.CodeAnalys
 	})
 
 	for _, signatureResults := range codeAnalysisFindings.SignatureWiseMatchResults {
-		for _, match := range signatureResults {
-			for _, condition := range match.MatchedConditions {
+		for _, signatureMatchResult := range signatureResults {
+			for _, condition := range signatureMatchResult.MatchedConditions {
 				for _, evidence := range condition.Evidences {
 					evidenceDetailString := "Unknown"
-					evidenceContent, exists := evidence.Metadata()
-					if exists {
-						evidenceDetailString = fmt.Sprintf("L%d:%d to\nL%d:%d",
-							evidenceContent.StartLine, evidenceContent.StartColumn,
-							evidenceContent.EndLine, evidenceContent.EndColumn)
+					evidenceMetadata := evidence.Metadata(signatureMatchResult.TreeData)
+					if evidenceMetadata.CallerIdentifierMetadata != nil {
+						evidenceDetailString = fmt.Sprintf(
+							"L%d:%d to\nL%d:%d",
+							evidenceMetadata.CallerIdentifierMetadata.StartLine+1,
+							evidenceMetadata.CallerIdentifierMetadata.StartColumn+1,
+							evidenceMetadata.CallerIdentifierMetadata.EndLine+1,
+							evidenceMetadata.CallerIdentifierMetadata.EndColumn+1,
+						)
 					}
 
 					conditionLocationString := fmt.Sprintf("%s: \n%s", condition.Condition.Type, condition.Condition.Value)
 					sigTable.AppendRow(table.Row{
-						match.MatchedSignature.Id,
-						match.MatchedLanguageCode,
+						signatureMatchResult.MatchedSignature.Id,
+						signatureMatchResult.MatchedLanguageCode,
 						conditionLocationString,
-						match.FilePath,
+						signatureMatchResult.FilePath,
 						evidenceDetailString,
 					})
 					sigTable.AppendSeparator()

--- a/pkg/reporter/templates/report.html
+++ b/pkg/reporter/templates/report.html
@@ -1,6 +1,4 @@
-package reporter
-
-var htmlTemplate = `<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -146,4 +144,4 @@ function toggleDetails(id, btn) {
 </footer>
 
 </body>
-</html>`
+</html>


### PR DESCRIPTION
With this new update of [code](https://github.com/safedep/code/), `xbom` is now able to identify precise call identifiers (keywords/phrases) that lead to the function call. More info - https://github.com/safedep/code/pull/34#issue-3152405261

Also improved html reporter with actual code snippets and mutli-snippet support for files

Example xbom for https://github.com/OmkarPh/dummy-app/ -

BOM - [sample.cdx.json](https://github.com/user-attachments/files/20820705/sample2.cdx.json)

![image](https://github.com/user-attachments/assets/f97db253-ed0d-497e-9b7c-d9472dcb29ed)
